### PR TITLE
Extending graphql

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,14 @@
 {
   "extends": "standard",
   "plugins": [
-    "react"
+    "react",
   ],
   "ecmaFeatures": {
-    "jsx": true
+    "jsx": true,
   },
   "rules": {
     "indent": [2, "tab"],
-    "semi": [2, "always"]
-  }
+    "semi": [2, "always"],
+    "comma-dangle": [2, "always-multiline"],
+  },
 }

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ node_modules
 
 .env
 ACCOUNTS.md
+
+graphql/schema.graphql

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -82,23 +82,20 @@ module.exports.location = new GraphQL.GraphQLObjectType({
 	},
 });
 
-// WIP
-// module.exports.date = new GraphQL.GraphQLObjectType({
-// 	name: 'KeystoneDate',
-// 	fields: {
-// 		format: {
-// 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-// 			args: {
-// 				tokens: {
-// 					type: GraphQL.GraphQLString,
-// 					default: 'Do MMM YYYY',
-// 				}
-// 			},
-// 			description: 'A formated string using http://momentjs.com/docs/#/displaying/format/',
-// 			resolve: (source, args) => {
-// 				// console.dir(source);
-// 				return source._.format(args.token);
-// 			}
-// 		},
-// 	},
-// })
+module.exports.date = new GraphQL.GraphQLObjectType({
+	name: 'KeystoneDate',
+	fields: {
+		format: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			args: {
+				stringOfTokens: {
+					type: GraphQL.GraphQLString,
+					default: 'Do MMM YYYY',
+					description: 'A formated string using Moment.js tokens ' +
+						'http://momentjs.com/docs/#/displaying/format/',
+				}
+			},
+			resolve: (source, args) => source.format(args.stringOfTokens),
+		},
+	},
+})

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -77,7 +77,7 @@ module.exports.location = new GraphQL.GraphQLObjectType({
 		},
 		geo: {
 			type: new GraphQL.GraphQLList(GraphQL.GraphQLString),
-			description: 'An array [longitude, latitude]'
+			description: 'An array [longitude, latitude]',
 		},
 	},
 });
@@ -93,9 +93,9 @@ module.exports.date = new GraphQL.GraphQLObjectType({
 					default: 'Do MMM YYYY',
 					description: 'A formated string using Moment.js tokens ' +
 						'http://momentjs.com/docs/#/displaying/format/',
-				}
+				},
 			},
 			resolve: (source, args) => source.format(args.stringOfTokens),
 		},
 	},
-})
+});

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -1,7 +1,7 @@
 var GraphQL = require('graphql');
 
 module.exports.name = new GraphQL.GraphQLObjectType({
-	name: 'UserName',
+	name: 'KeystoneName',
 	fields: {
 		first: {
 			type: GraphQL.GraphQLString,
@@ -14,3 +14,24 @@ module.exports.name = new GraphQL.GraphQLObjectType({
 		},
 	},
 });
+
+// WIP
+// module.exports.date = new GraphQL.GraphQLObjectType({
+// 	name: 'KeystoneDate',
+// 	fields: {
+// 		format: {
+// 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+// 			args: {
+// 				tokens: {
+// 					type: GraphQL.GraphQLString,
+// 					default: 'Do MMM YYYY',
+// 				}
+// 			},
+// 			description: 'A formated string using http://momentjs.com/docs/#/displaying/format/',
+// 			resolve: (source, args) => {
+// 				// console.dir(source);
+// 				return source._.format(args.token);
+// 			}
+// 		},
+// 	},
+// })

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -91,7 +91,25 @@ module.exports.date = new GraphQL.GraphQLObjectType({
 				stringOfTokens: {
 					type: GraphQL.GraphQLString,
 					default: 'Do MMM YYYY',
-					description: 'A formated string using Moment.js tokens ' +
+					description: 'A formated time using Moment.js tokens ' +
+						'http://momentjs.com/docs/#/displaying/format/',
+				},
+			},
+			resolve: (source, args) => source.format(args.stringOfTokens),
+		},
+	},
+});
+
+module.exports.datetime = new GraphQL.GraphQLObjectType({
+	name: 'KeystoneDatetime',
+	fields: {
+		format: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			args: {
+				stringOfTokens: {
+					type: GraphQL.GraphQLString,
+					default: 'Do MMM YYYY hh:mm:ss a',
+					description: 'A formated datetime using Moment.js tokens ' +
 						'http://momentjs.com/docs/#/displaying/format/',
 				},
 			},

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -145,3 +145,36 @@ module.exports.markdown = new GraphQL.GraphQLObjectType({
 		},
 	},
 });
+
+module.exports.email = new GraphQL.GraphQLObjectType({
+	name: 'KeystoneEmail',
+	fields: {
+		email: {
+			type: GraphQL.GraphQLString,
+		},
+		gravatarUrl: {
+			type: GraphQL.GraphQLString,
+			args: {
+				size: {
+					type: GraphQL.GraphQLInt,
+					defaultValue: 80,
+					description: 'Size of images ranging from 1 to 2048 pixels, square',
+				},
+				defaultImage: {
+					type: GraphQL.GraphQLString,
+					defaultValue: 'identicon',
+					description: 'default image url encoded href or one of the built ' +
+						'in options: 404, mm, identicon, monsterid, wavatar, retro, blank',
+				},
+				rating: {
+					type: GraphQL.GraphQLString,
+					defaultValue: 'g',
+					description: 'the rating of the image, either rating, g, pg, r or x',
+				},
+			},
+			description: 'Protocol-less Gravatar image request URL',
+			resolve: (source, args) =>
+				source.gravatarUrl(args.size, args.defaultImage, args.rating),
+		},
+	},
+});

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -82,39 +82,37 @@ module.exports.location = new GraphQL.GraphQLObjectType({
 	},
 });
 
-module.exports.date = new GraphQL.GraphQLObjectType({
-	name: 'KeystoneDate',
-	fields: {
+module.exports.date = (field) => ({
+	type: GraphQL.GraphQLString,
+	args: {
 		format: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			args: {
-				stringOfTokens: {
-					type: GraphQL.GraphQLString,
-					default: 'Do MMM YYYY',
-					description: 'A formated time using Moment.js tokens ' +
-						'http://momentjs.com/docs/#/displaying/format/',
-				},
-			},
-			resolve: (source, args) => source.format(args.stringOfTokens),
+			type: GraphQL.GraphQLString,
+			description: 'A formated time using Moment.js tokens ' +
+				'http://momentjs.com/docs/#/displaying/format/',
 		},
+	},
+	resolve: (source, args) => {
+		if (args.format) {
+			return field.format(source, args.format);
+		}
+		return source.get(field.path);
 	},
 });
 
-module.exports.datetime = new GraphQL.GraphQLObjectType({
-	name: 'KeystoneDatetime',
-	fields: {
+module.exports.datetime = (field) => ({
+	type: GraphQL.GraphQLString,
+	args: {
 		format: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			args: {
-				stringOfTokens: {
-					type: GraphQL.GraphQLString,
-					default: 'Do MMM YYYY hh:mm:ss a',
-					description: 'A formated datetime using Moment.js tokens ' +
-						'http://momentjs.com/docs/#/displaying/format/',
-				},
-			},
-			resolve: (source, args) => source.format(args.stringOfTokens),
+			type: GraphQL.GraphQLString,
+			description: 'A formated datetime using Moment.js tokens ' +
+				'http://momentjs.com/docs/#/displaying/format/',
 		},
+	},
+	resolve: (source, args) => {
+		if (args.format) {
+			return field.format(source, args.format);
+		}
+		return source.get(field.path);
 	},
 });
 

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -15,6 +15,39 @@ module.exports.name = new GraphQL.GraphQLObjectType({
 	},
 });
 
+module.exports.cloudinaryImage = new GraphQL.GraphQLObjectType({
+	name: 'KeystoneCloudinaryImage',
+	fields: {
+		public_id: {
+			type: GraphQL.GraphQLString,
+		},
+		version: {
+			type: GraphQL.GraphQLInt,
+		},
+		signature: {
+			type: GraphQL.GraphQLString,
+		},
+		format: {
+			type: GraphQL.GraphQLString,
+		},
+		resource_type: {
+			type: GraphQL.GraphQLString,
+		},
+		url: {
+			type: GraphQL.GraphQLString,
+		},
+		width: {
+			type: GraphQL.GraphQLInt,
+		},
+		height: {
+			type: GraphQL.GraphQLInt,
+		},
+		secure_url: {
+			type: GraphQL.GraphQLString,
+		},
+	},
+});
+
 // WIP
 // module.exports.date = new GraphQL.GraphQLObjectType({
 // 	name: 'KeystoneDate',

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -1,0 +1,16 @@
+var GraphQL = require('graphql');
+
+module.exports.name = new GraphQL.GraphQLObjectType({
+	name: 'UserName',
+	fields: {
+		first: {
+			type: GraphQL.GraphQLString,
+		},
+		last: {
+			type: GraphQL.GraphQLString,
+		},
+		full: {
+			type: GraphQL.GraphQLString,
+		},
+	},
+});

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -131,3 +131,17 @@ module.exports.link = new GraphQL.GraphQLObjectType({
 		},
 	},
 });
+
+module.exports.markdown = new GraphQL.GraphQLObjectType({
+	name: 'KeystoneMarkdown',
+	fields: {
+		md: {
+			type: GraphQL.GraphQLString,
+			description: 'source markdown text',
+		},
+		html: {
+			type: GraphQL.GraphQLString,
+			description: 'generated html code',
+		},
+	},
+});

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -48,6 +48,40 @@ module.exports.cloudinaryImage = new GraphQL.GraphQLObjectType({
 	},
 });
 
+module.exports.location = new GraphQL.GraphQLObjectType({
+	name: 'KeystoneLocation',
+	fields: {
+		name: {
+			type: GraphQL.GraphQLString,
+		},
+		number: {
+			type: GraphQL.GraphQLInt,
+		},
+		street1: {
+			type: GraphQL.GraphQLString,
+		},
+		street2: {
+			type: GraphQL.GraphQLString,
+		},
+		suburb: {
+			type: GraphQL.GraphQLString,
+		},
+		state: {
+			type: GraphQL.GraphQLString,
+		},
+		postcode: {
+			type: GraphQL.GraphQLInt,
+		},
+		country: {
+			type: GraphQL.GraphQLInt,
+		},
+		geo: {
+			type: new GraphQL.GraphQLList(GraphQL.GraphQLString),
+			description: 'An array [longitude, latitude]'
+		},
+	},
+});
+
 // WIP
 // module.exports.date = new GraphQL.GraphQLObjectType({
 // 	name: 'KeystoneDate',

--- a/graphql/keystoneTypes.js
+++ b/graphql/keystoneTypes.js
@@ -117,3 +117,17 @@ module.exports.datetime = new GraphQL.GraphQLObjectType({
 		},
 	},
 });
+
+module.exports.link = new GraphQL.GraphQLObjectType({
+	name: 'KeystoneLink',
+	fields: {
+		raw: {
+			type: GraphQL.GraphQLString,
+			description: 'The raw unformmated URL',
+		},
+		format: {
+			type: GraphQL.GraphQLString,
+			description: 'The URL after being passed through the `format Function` option',
+		},
+	},
+});

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -116,30 +116,32 @@ function getTalk (id) {
 	return Talk.model.findById(id);
 }
 
-module.exports = new GraphQL.GraphQLSchema({
-	query: new GraphQL.GraphQLObjectType({
-		name: 'RootQueryType',
-		fields: () => ({
-			meetup: {
-				type: meetupType,
-				args: {
-					id: {
-						description: 'id of the meetup, can be "next" or "last"',
-						type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-					},
+var queryRootType = new GraphQL.GraphQLObjectType({
+	name: 'Query',
+	fields: () => ({
+		meetup: {
+			type: meetupType,
+			args: {
+				id: {
+					description: 'id of the meetup, can be "next" or "last"',
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
 				},
-				resolve: (root, args) => getMeetup(args.id),
 			},
-			talk: {
-				type: talkType,
-				args: {
-					id: {
-						description: 'id of the talk',
-						type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-					},
+			resolve: (root, args) => getMeetup(args.id),
+		},
+		talk: {
+			type: talkType,
+			args: {
+				id: {
+					description: 'id of the talk',
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
 				},
-				resolve: (root, args) => getTalk(args.id),
 			},
-		}),
+			resolve: (root, args) => getTalk(args.id),
+		},
 	}),
+});
+
+module.exports = new GraphQL.GraphQLSchema({
+	query: queryRootType
 });

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -185,7 +185,7 @@ var organisationType = new GraphQL.GraphQLObjectType({
 		website: { type: GraphQL.GraphQLString },
 		isHiring: { type: GraphQL.GraphQLBoolean },
 		description: { type: GraphQL.GraphQLString },
-		location: { type: GraphQL.GraphQLString },
+		location: { type: keystoneTypes.location },
 		members: {
 			type: new GraphQL.GraphQLList(userType),
 			resolve: (source) =>

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -1,4 +1,5 @@
 var GraphQL = require('graphql');
+var keystoneTypes = require('./keystoneTypes');
 
 var keystone = require('keystone');
 var Meetup = keystone.list('Meetup');
@@ -86,26 +87,11 @@ var meetupType = new GraphQL.GraphQLObjectType({
 	},
 });
 
-var userNameType = new GraphQL.GraphQLObjectType({
-	name: 'UserName',
-	fields: {
-		first: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-		},
-		last: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-		},
-		full: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-		},
-	},
-});
-
 var userType = new GraphQL.GraphQLObjectType({
 	name: 'User',
 	fields: {
 		name: {
-			type: new GraphQL.GraphQLNonNull(userNameType),
+			type: new GraphQL.GraphQLNonNull(keystoneTypes.name),
 		},
 		email: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -227,6 +227,26 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 			},
 			resolve: (_, args) => Organisation.model.findById(args.id).exec(),
 		},
+		user: {
+			type: userType,
+			args: {
+				id: {
+					description: 'id of the user',
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
+				},
+			},
+			resolve: (_, args) => User.model.findById(args.id).exec(),
+		},
+		rsvp: {
+			type: rsvpType,
+			args: {
+				id: {
+					description: 'id of the RSVP',
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
+				},
+			},
+			resolve: (_, args) => RSVP.model.findById(args.id).exec(),
+		},
 	},
 });
 

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -31,8 +31,8 @@ var meetupStateEnum = new GraphQL.GraphQLEnumType({
 		},
 		past: {
 			description: 'Past'
-		},
-	},
+		}
+	}
 });
 
 var meetupType = new GraphQL.GraphQLObjectType({
@@ -40,47 +40,47 @@ var meetupType = new GraphQL.GraphQLObjectType({
 	fields: () => ({
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			description: 'The id of the meetup.',
+			description: 'The id of the meetup.'
 		},
 		name: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			description: 'The name of the meetup.',
+			description: 'The name of the meetup.'
 		},
 		publishedDate: {
-			type: GraphQL.GraphQLString,
+			type: GraphQL.GraphQLString
 		},
 		state: {
-			type: new GraphQL.GraphQLNonNull(meetupStateEnum),
+			type: new GraphQL.GraphQLNonNull(meetupStateEnum)
 		},
 		startDate: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
 		},
 		endDate: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
 		},
 		place: {
-			type: GraphQL.GraphQLString,
+			type: GraphQL.GraphQLString
 		},
 		map: {
-			type: GraphQL.GraphQLString,
+			type: GraphQL.GraphQLString
 		},
 		description: {
-			type: GraphQL.GraphQLString,
+			type: GraphQL.GraphQLString
 		},
 		maxRSVPs: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt)
 		},
 		totalRSVPs: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt)
 		},
 		url: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
 		},
 		remainingRSVPs: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt)
 		},
 		rsvpsAvailable: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLBoolean),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLBoolean)
 		}
 	})
 });
@@ -90,31 +90,31 @@ var talkType = new GraphQL.GraphQLObjectType({
 	fields: () => ({
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			description: 'The id of the talk.',
+			description: 'The id of the talk.'
 		},
 		name: {
 			type: GraphQL.GraphQLString,
-			description: 'The title of the talk.',
+			description: 'The title of the talk.'
 		},
 		isLightningTalk: {
 			type: GraphQL.GraphQLBoolean,
-			description: 'Whether the talk is a Lightning talk',
+			description: 'Whether the talk is a Lightning talk'
 		},
 		meetup: {
 			type: meetupType,
-			description: 'The Meetup the talk is scheduled for',
+			description: 'The Meetup the talk is scheduled for'
 		},
 		// TODO: who (relationship to User)
 		description: {
-			type: GraphQL.GraphQLString,
+			type: GraphQL.GraphQLString
 		},
 		slides: {
-			type: GraphQL.GraphQLString,
+			type: GraphQL.GraphQLString
 		},
 		link: {
-			type: GraphQL.GraphQLString,
-		},
-	}),
+			type: GraphQL.GraphQLString
+		}
+	})
 });
 
 function getTalk (id) {
@@ -130,9 +130,9 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 				id: {
 					description: 'id of the meetup, can be "next" or "last"',
 					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-				},
+				}
 			},
-			resolve: (root, args) => getMeetup(args.id),
+			resolve: (root, args) => getMeetup(args.id)
 		},
 		talk: {
 			type: talkType,
@@ -140,11 +140,11 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 				id: {
 					description: 'id of the talk',
 					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-				},
+				}
 			},
-			resolve: (root, args) => getTalk(args.id),
-		},
-	}),
+			resolve: (root, args) => getTalk(args.id)
+		}
+	})
 });
 
 module.exports = new GraphQL.GraphQLSchema({

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -6,11 +6,13 @@ var Talk = keystone.list('Talk');
 
 function getMeetup (id) {
 	if (id === 'next') {
-		return Meetup.model.findOne().sort('-startDate').where('state', 'active');
+		return Meetup.model.findOne().sort('-startDate')
+						.where('state', 'active').exec();
 	} else if (id === 'last') {
-		return Meetup.model.findOne().sort('-startDate').where('state', 'past');
+		return Meetup.model.findOne().sort('-startDate')
+						.where('state', 'past').exec();
 	} else {
-		return Meetup.model.findById(id);
+		return Meetup.model.findById(id).exec();
 	}
 }
 

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -167,6 +167,12 @@ var rsvpType = new GraphQL.GraphQLObjectType({
 			resolve: (source) => User.model.findById(source.who).exec(),
 		},
 		attending: { type: GraphQL.GraphQLBoolean },
+		createdAt: {
+			type: GraphQL.GraphQLString,
+		},
+		changedAt: {
+			type: GraphQL.GraphQLString,
+		},
 	},
 });
 

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -5,6 +5,7 @@ var keystone = require('keystone');
 var Meetup = keystone.list('Meetup');
 var Talk = keystone.list('Talk');
 var User = keystone.list('User');
+var RSVP = keystone.list('RSVP');
 
 function getMeetup (id) {
 	if (id === 'next') {
@@ -88,19 +89,11 @@ var meetupType = new GraphQL.GraphQLObjectType({
 			type: new GraphQL.GraphQLList(talkType),
 			resolve: (source) => Talk.model.find().where('meetup', source.id).exec(),
 		},
+		rsvps: {
+			type: new GraphQL.GraphQLList(rsvpType),
+			resolve: (source) => RSVP.model.find().where('meetup', source.id).exec(),
+		},
 	}),
-});
-
-var userType = new GraphQL.GraphQLObjectType({
-	name: 'User',
-	fields: {
-		name: {
-			type: new GraphQL.GraphQLNonNull(keystoneTypes.name),
-		},
-		email: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-		},
-	},
 });
 
 var talkType = new GraphQL.GraphQLObjectType({
@@ -140,6 +133,33 @@ var talkType = new GraphQL.GraphQLObjectType({
 			type: GraphQL.GraphQLString,
 		},
 	}),
+});
+
+var userType = new GraphQL.GraphQLObjectType({
+	name: 'User',
+	fields: {
+		name: {
+			type: new GraphQL.GraphQLNonNull(keystoneTypes.name),
+		},
+		email: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+		},
+	},
+});
+
+var rsvpType = new GraphQL.GraphQLObjectType({
+	name: 'RSVP',
+	fields: {
+		meetup: {
+			type: new GraphQL.GraphQLNonNull(meetupType),
+			resolve: (source) => Meetup.model.findById(source.meetup).exec(),
+		},
+		who: {
+			type: new GraphQL.GraphQLNonNull(userType),
+			resolve: (source) => User.model.findById(source.who).exec(),
+		},
+		attending: { type: GraphQL.GraphQLBoolean },
+	},
 });
 
 var queryRootType = new GraphQL.GraphQLObjectType({

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -131,10 +131,18 @@ var talkType = new GraphQL.GraphQLObjectType({
 			type: GraphQL.GraphQLString,
 		},
 		slides: {
-			type: GraphQL.GraphQLString,
+			type: keystoneTypes.link,
+			resolve: (source) => ({
+				raw: source.slides,
+				format: source._.slides.format,
+			}),
 		},
 		link: {
-			type: GraphQL.GraphQLString,
+			type: keystoneTypes.link,
+			resolve: (source) => ({
+				raw: source.link,
+				format: source._.link.format,
+			}),
 		},
 	}),
 });

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -42,7 +42,7 @@ var meetupType = new GraphQL.GraphQLObjectType({
 	name: 'Meetup',
 	fields: () => ({
 		id: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
 			description: 'The id of the meetup.',
 		},
 		name: {
@@ -100,7 +100,7 @@ var talkType = new GraphQL.GraphQLObjectType({
 	name: 'Talk',
 	fields: () => ({
 		id: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
 			description: 'The id of the talk.',
 		},
 		name: {
@@ -138,6 +138,10 @@ var talkType = new GraphQL.GraphQLObjectType({
 var userType = new GraphQL.GraphQLObjectType({
 	name: 'User',
 	fields: {
+		id: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
+			description: 'The id of the user.',
+		},
 		name: {
 			type: new GraphQL.GraphQLNonNull(keystoneTypes.name),
 		},
@@ -150,6 +154,10 @@ var userType = new GraphQL.GraphQLObjectType({
 var rsvpType = new GraphQL.GraphQLObjectType({
 	name: 'RSVP',
 	fields: {
+		id: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
+			description: 'The id of the RSVP.',
+		},
 		meetup: {
 			type: new GraphQL.GraphQLNonNull(meetupType),
 			resolve: (source) => Meetup.model.findById(source.meetup).exec(),
@@ -170,7 +178,7 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 			args: {
 				id: {
 					description: 'id of the meetup, can be "next" or "last"',
-					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
 				},
 			},
 			resolve: (_, args) => getMeetup(args.id),
@@ -180,7 +188,7 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 			args: {
 				id: {
 					description: 'id of the talk',
-					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
 				},
 			},
 			resolve: (_, args) => Talk.model.findById(args.id).exec(),

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -197,7 +197,7 @@ var organisationType = new GraphQL.GraphQLObjectType({
 		logo: { type: keystoneTypes.cloudinaryImage },
 		website: { type: GraphQL.GraphQLString },
 		isHiring: { type: GraphQL.GraphQLBoolean },
-		description: { type: GraphQL.GraphQLString },
+		description: { type: keystoneTypes.markdown },
 		location: { type: keystoneTypes.location },
 		members: {
 			type: new GraphQL.GraphQLList(userType),

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -39,7 +39,7 @@ var meetupStateEnum = new GraphQL.GraphQLEnumType({
 
 var meetupType = new GraphQL.GraphQLObjectType({
 	name: 'Meetup',
-	fields: {
+	fields: () => ({
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 			description: 'The id of the meetup.',
@@ -84,7 +84,11 @@ var meetupType = new GraphQL.GraphQLObjectType({
 		rsvpsAvailable: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLBoolean),
 		},
-	},
+		talks: {
+			type: new GraphQL.GraphQLList(talkType),
+			resolve: (source) => Talk.model.find().where('meetup', source.id).exec(),
+		},
+	}),
 });
 
 var userType = new GraphQL.GraphQLObjectType({
@@ -101,7 +105,7 @@ var userType = new GraphQL.GraphQLObjectType({
 
 var talkType = new GraphQL.GraphQLObjectType({
 	name: 'Talk',
-	fields: {
+	fields: () => ({
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 			description: 'The id of the talk.',
@@ -135,7 +139,7 @@ var talkType = new GraphQL.GraphQLObjectType({
 		link: {
 			type: GraphQL.GraphQLString,
 		},
-	},
+	}),
 });
 
 function getTalk (id) {

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -149,7 +149,7 @@ var talkType = new GraphQL.GraphQLObjectType({
 
 var userType = new GraphQL.GraphQLObjectType({
 	name: 'User',
-	fields: {
+	fields: () => ({
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
 			description: 'The id of the user.',
@@ -160,7 +160,17 @@ var userType = new GraphQL.GraphQLObjectType({
 		email: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 		},
-	},
+		talks: {
+			type: new GraphQL.GraphQLList(talkType),
+			resolve: (source) =>
+				Talk.model.find().where('who', source.id).exec(),
+		},
+		rsvps: {
+			type: new GraphQL.GraphQLList(rsvpType),
+			resolve: (source) =>
+				RSVP.model.find().where('who', source.id).exec(),
+		},
+	}),
 });
 
 var rsvpType = new GraphQL.GraphQLObjectType({

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -21,16 +21,16 @@ var meetupStateEnum = new GraphQL.GraphQLEnumType({
 	description: 'The state of the meetup',
 	values: {
 		draft: {
-			description: 'Draft'
+			description: "No published date, it's a draft meetup"
 		},
 		scheduled: {
-			description: 'Scheduled'
+			description: "Publish date is before today, it's a scheduled meetup"
 		},
 		active: {
-			description: 'Active'
+			description: "Publish date is after today, it's an active meetup"
 		},
 		past: {
-			description: 'Past'
+			description: "Meetup date plus one day is after today, it's a past meetup"
 		}
 	}
 });

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -1,6 +1,6 @@
 var GraphQL = require('graphql');
-var keystone = require('keystone');
 
+var keystone = require('keystone');
 var Meetup = keystone.list('Meetup');
 var Talk = keystone.list('Talk');
 
@@ -21,19 +21,15 @@ var meetupStateEnum = new GraphQL.GraphQLEnumType({
 	description: 'The state of the meetup',
 	values: {
 		draft: {
-			value: 'draft',
 			description: 'Draft'
 		},
 		scheduled: {
-			value: 'scheduled',
 			description: 'Scheduled'
 		},
 		active: {
-			value: 'active',
 			description: 'Active'
 		},
 		past: {
-			value: 'past',
 			description: 'Past'
 		},
 	},

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -158,7 +158,11 @@ var userType = new GraphQL.GraphQLObjectType({
 			type: new GraphQL.GraphQLNonNull(keystoneTypes.name),
 		},
 		email: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			type: keystoneTypes.email,
+			resolve: (source) => ({
+				email: source.email,
+				gravatarUrl: source._.email.gravatarUrl,
+			}),
 		},
 		talks: {
 			type: new GraphQL.GraphQLList(talkType),

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -169,10 +169,12 @@ var rsvpType = new GraphQL.GraphQLObjectType({
 		},
 		attending: { type: GraphQL.GraphQLBoolean },
 		createdAt: {
-			type: GraphQL.GraphQLString,
+			type: keystoneTypes.date,
+			resolve: (source) => source._.createdAt,
 		},
 		changedAt: {
-			type: GraphQL.GraphQLString,
+			type: keystoneTypes.date,
+			resolve: (source) => source._.changedAt,
 		},
 	},
 });

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -22,18 +22,18 @@ var meetupStateEnum = new GraphQL.GraphQLEnumType({
 	description: 'The state of the meetup',
 	values: {
 		draft: {
-			description: "No published date, it's a draft meetup"
+			description: "No published date, it's a draft meetup",
 		},
 		scheduled: {
-			description: "Publish date is before today, it's a scheduled meetup"
+			description: "Publish date is before today, it's a scheduled meetup",
 		},
 		active: {
-			description: "Publish date is after today, it's an active meetup"
+			description: "Publish date is after today, it's an active meetup",
 		},
 		past: {
-			description: "Meetup date plus one day is after today, it's a past meetup"
-		}
-	}
+			description: "Meetup date plus one day is after today, it's a past meetup",
+		},
+	},
 });
 
 var meetupType = new GraphQL.GraphQLObjectType({
@@ -41,76 +41,76 @@ var meetupType = new GraphQL.GraphQLObjectType({
 	fields: {
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			description: 'The id of the meetup.'
+			description: 'The id of the meetup.',
 		},
 		name: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			description: 'The name of the meetup.'
+			description: 'The name of the meetup.',
 		},
 		publishedDate: {
-			type: GraphQL.GraphQLString
+			type: GraphQL.GraphQLString,
 		},
 		state: {
-			type: new GraphQL.GraphQLNonNull(meetupStateEnum)
+			type: new GraphQL.GraphQLNonNull(meetupStateEnum),
 		},
 		startDate: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 		},
 		endDate: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 		},
 		place: {
-			type: GraphQL.GraphQLString
+			type: GraphQL.GraphQLString,
 		},
 		map: {
-			type: GraphQL.GraphQLString
+			type: GraphQL.GraphQLString,
 		},
 		description: {
-			type: GraphQL.GraphQLString
+			type: GraphQL.GraphQLString,
 		},
 		maxRSVPs: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt)
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
 		},
 		totalRSVPs: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt)
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
 		},
 		url: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 		},
 		remainingRSVPs: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt)
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
 		},
 		rsvpsAvailable: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLBoolean)
-		}
-	}
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLBoolean),
+		},
+	},
 });
 
 var userNameType = new GraphQL.GraphQLObjectType({
 	name: 'UserName',
 	fields: {
 		first: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 		},
 		last: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 		},
 		full: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-		}
-	}
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+		},
+	},
 });
 
 var userType = new GraphQL.GraphQLObjectType({
 	name: 'User',
 	fields: {
 		name: {
-			type: new GraphQL.GraphQLNonNull(userNameType)
+			type: new GraphQL.GraphQLNonNull(userNameType),
 		},
 		email: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-		}
-	}
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+		},
+	},
 });
 
 var talkType = new GraphQL.GraphQLObjectType({
@@ -118,38 +118,38 @@ var talkType = new GraphQL.GraphQLObjectType({
 	fields: {
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			description: 'The id of the talk.'
+			description: 'The id of the talk.',
 		},
 		name: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
-			description: 'The title of the talk.'
+			description: 'The title of the talk.',
 		},
 		isLightningTalk: {
 			type: GraphQL.GraphQLBoolean,
-			description: 'Whether the talk is a Lightning talk'
+			description: 'Whether the talk is a Lightning talk',
 		},
 		meetup: {
 			type: new GraphQL.GraphQLNonNull(meetupType),
 			description: 'The Meetup the talk is scheduled for',
 			resolve: (source, args, info) =>
-				Meetup.model.findById(source.meetup).exec()
+				Meetup.model.findById(source.meetup).exec(),
 		},
 		who: {
 			type: new GraphQL.GraphQLList(userType),
 			description: 'A list of at least one User running the talk',
 			resolve: (source, args, info) =>
-				User.model.find().where('_id').in(source.who).exec()
+				User.model.find().where('_id').in(source.who).exec(),
 		},
 		description: {
-			type: GraphQL.GraphQLString
+			type: GraphQL.GraphQLString,
 		},
 		slides: {
-			type: GraphQL.GraphQLString
+			type: GraphQL.GraphQLString,
 		},
 		link: {
-			type: GraphQL.GraphQLString
-		}
-	}
+			type: GraphQL.GraphQLString,
+		},
+	},
 });
 
 function getTalk (id) {
@@ -168,24 +168,24 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 			args: {
 				id: {
 					description: 'id of the meetup, can be "next" or "last"',
-					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-				}
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+				},
 			},
-			resolve: (root, args) => getMeetup(args.id)
+			resolve: (root, args) => getMeetup(args.id),
 		},
 		talk: {
 			type: talkType,
 			args: {
 				id: {
 					description: 'id of the talk',
-					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-				}
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+				},
 			},
-			resolve: (root, args) => getTalk(args.id)
-		}
-	}
+			resolve: (root, args) => getTalk(args.id),
+		},
+	},
 });
 
 module.exports = new GraphQL.GraphQLSchema({
-	query: queryRootType
+	query: queryRootType,
 });

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -93,7 +93,7 @@ var talkType = new GraphQL.GraphQLObjectType({
 			description: 'The id of the talk.'
 		},
 		name: {
-			type: GraphQL.GraphQLString,
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 			description: 'The title of the talk.'
 		},
 		isLightningTalk: {
@@ -101,7 +101,7 @@ var talkType = new GraphQL.GraphQLObjectType({
 			description: 'Whether the talk is a Lightning talk'
 		},
 		meetup: {
-			type: meetupType,
+			type: new GraphQL.GraphQLNonNull(meetupType),
 			description: 'The Meetup the talk is scheduled for'
 		},
 		// TODO: who (relationship to User)

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -43,20 +43,20 @@ var meetupType = new GraphQL.GraphQLObjectType({
 			description: 'The id of the meetup.',
 		},
 		name: {
-			type: GraphQL.GraphQLString,
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 			description: 'The name of the meetup.',
 		},
 		publishedDate: {
 			type: GraphQL.GraphQLString,
 		},
 		state: {
-			type: meetupStateEnum,
+			type: new GraphQL.GraphQLNonNull(meetupStateEnum),
 		},
 		startDate: {
-			type: GraphQL.GraphQLString,
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 		},
 		endDate: {
-			type: GraphQL.GraphQLString,
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 		},
 		place: {
 			type: GraphQL.GraphQLString,
@@ -68,10 +68,10 @@ var meetupType = new GraphQL.GraphQLObjectType({
 			type: GraphQL.GraphQLString,
 		},
 		maxRSVPs: {
-			type: GraphQL.GraphQLInt,
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
 		},
 		totalRSVPs: {
-			type: GraphQL.GraphQLInt,
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
 		},
 	}),
 });

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -142,14 +142,6 @@ var talkType = new GraphQL.GraphQLObjectType({
 	}),
 });
 
-function getTalk (id) {
-	/**
-	* TODO reduce query cost and run second query in who field `resolve` function
-	* making the who lookup optional
-	*/
-	return Talk.model.findById(id).exec();
-}
-
 var queryRootType = new GraphQL.GraphQLObjectType({
 	name: 'Query',
 	fields: {
@@ -161,7 +153,7 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 				},
 			},
-			resolve: (root, args) => getMeetup(args.id),
+			resolve: (_, args) => getMeetup(args.id),
 		},
 		talk: {
 			type: talkType,
@@ -171,7 +163,7 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 				},
 			},
-			resolve: (root, args) => getTalk(args.id),
+			resolve: (_, args) => Talk.model.findById(args.id).exec(),
 		},
 	},
 });

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -3,6 +3,7 @@ var GraphQL = require('graphql');
 var keystone = require('keystone');
 var Meetup = keystone.list('Meetup');
 var Talk = keystone.list('Talk');
+var User = keystone.list('User');
 
 function getMeetup (id) {
 	if (id === 'next') {
@@ -129,11 +130,15 @@ var talkType = new GraphQL.GraphQLObjectType({
 		},
 		meetup: {
 			type: new GraphQL.GraphQLNonNull(meetupType),
-			description: 'The Meetup the talk is scheduled for'
+			description: 'The Meetup the talk is scheduled for',
+			resolve: (source, args, info) =>
+				Meetup.model.findById(source.meetup).exec()
 		},
 		who: {
 			type: new GraphQL.GraphQLList(userType),
-			description: 'A list of at least one User running the talk'
+			description: 'A list of at least one User running the talk',
+			resolve: (source, args, info) =>
+				User.model.find().where('_id').in(source.who).exec()
 		},
 		description: {
 			type: GraphQL.GraphQLString
@@ -152,7 +157,7 @@ function getTalk (id) {
 	* TODO reduce query cost and run second query in who field `resolve` function
 	* making the who lookup optional
 	*/
-	return Talk.model.findById(id).populate('who').exec();
+	return Talk.model.findById(id).exec();
 }
 
 var queryRootType = new GraphQL.GraphQLObjectType({

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -114,7 +114,7 @@ function getTalk (id) {
 	return Talk.model.findById(id);
 }
 
-var schema = new GraphQL.GraphQLSchema({
+module.exports = new GraphQL.GraphQLSchema({
 	query: new GraphQL.GraphQLObjectType({
 		name: 'RootQueryType',
 		fields: () => ({
@@ -141,10 +141,3 @@ var schema = new GraphQL.GraphQLSchema({
 		}),
 	}),
 });
-
-module.exports = function (req, res) {
-	GraphQL.graphql(schema, req.body)
-		.then((result) => {
-			res.send(JSON.stringify(result, null, 2));
-		});
-}

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -73,7 +73,16 @@ var meetupType = new GraphQL.GraphQLObjectType({
 		totalRSVPs: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
 		},
-	}),
+		url: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+		},
+		remainingRSVPs: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLInt),
+		},
+		rsvpsAvailable: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLBoolean),
+		}
+	})
 });
 
 var talkType = new GraphQL.GraphQLObjectType({

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -37,7 +37,7 @@ var meetupStateEnum = new GraphQL.GraphQLEnumType({
 
 var meetupType = new GraphQL.GraphQLObjectType({
 	name: 'Meetup',
-	fields: () => ({
+	fields: {
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 			description: 'The id of the meetup.'
@@ -82,12 +82,39 @@ var meetupType = new GraphQL.GraphQLObjectType({
 		rsvpsAvailable: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLBoolean)
 		}
-	})
+	}
+});
+
+var userNameType = new GraphQL.GraphQLObjectType({
+	name: 'UserName',
+	fields: {
+		first: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+		},
+		last: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+		},
+		full: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+		}
+	}
+});
+
+var userType = new GraphQL.GraphQLObjectType({
+	name: 'User',
+	fields: {
+		name: {
+			type: new GraphQL.GraphQLNonNull(userNameType)
+		},
+		email: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+		}
+	}
 });
 
 var talkType = new GraphQL.GraphQLObjectType({
 	name: 'Talk',
-	fields: () => ({
+	fields: {
 		id: {
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 			description: 'The id of the talk.'
@@ -117,7 +144,7 @@ var talkType = new GraphQL.GraphQLObjectType({
 		link: {
 			type: GraphQL.GraphQLString
 		}
-	})
+	}
 });
 
 function getTalk (id) {
@@ -128,36 +155,9 @@ function getTalk (id) {
 	return Talk.model.findById(id).populate('who').exec();
 }
 
-var userType = new GraphQL.GraphQLObjectType({
-	name: 'User',
-	fields: () => ({
-		name: {
-			type: new GraphQL.GraphQLNonNull(userNameType)
-		},
-		email: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-		}
-	})
-});
-
-var userNameType = new GraphQL.GraphQLObjectType({
-	name: 'UserName',
-	fields: () => ({
-		first: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-		},
-		last: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-		},
-		full: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
-		}
-	})
-});
-
 var queryRootType = new GraphQL.GraphQLObjectType({
 	name: 'Query',
-	fields: () => ({
+	fields: {
 		meetup: {
 			type: meetupType,
 			args: {
@@ -178,7 +178,7 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 			},
 			resolve: (root, args) => getTalk(args.id)
 		}
-	})
+	}
 });
 
 module.exports = new GraphQL.GraphQLSchema({

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -181,7 +181,7 @@ var organisationType = new GraphQL.GraphQLObjectType({
 	name: 'Organisation',
 	fields: {
 		name: { type: GraphQL.GraphQLString },
-		logo: { type: GraphQL.GraphQLString },
+		logo: { type: keystoneTypes.cloudinaryImage },
 		website: { type: GraphQL.GraphQLString },
 		isHiring: { type: GraphQL.GraphQLBoolean },
 		description: { type: GraphQL.GraphQLString },

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -50,21 +50,12 @@ var meetupType = new GraphQL.GraphQLObjectType({
 			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
 			description: 'The name of the meetup.',
 		},
-		publishedDate: {
-			type: keystoneTypes.date,
-			resolve: (source) => source._.publishedDate,
-		},
+		publishedDate: keystoneTypes.date(Meetup.fields.publishedDate),
 		state: {
 			type: new GraphQL.GraphQLNonNull(meetupStateEnum),
 		},
-		startDate: {
-			type: keystoneTypes.datetime,
-			resolve: (source) => source._.startDate,
-		},
-		endDate: {
-			type: keystoneTypes.datetime,
-			resolve: (source) => source._.endDate,
-		},
+		startDate: keystoneTypes.datetime(Meetup.fields.startDate),
+		endDate: keystoneTypes.datetime(Meetup.fields.endDate),
 		place: {
 			type: GraphQL.GraphQLString,
 		},
@@ -193,14 +184,8 @@ var rsvpType = new GraphQL.GraphQLObjectType({
 			resolve: (source) => User.model.findById(source.who).exec(),
 		},
 		attending: { type: GraphQL.GraphQLBoolean },
-		createdAt: {
-			type: keystoneTypes.date,
-			resolve: (source) => source._.createdAt,
-		},
-		changedAt: {
-			type: keystoneTypes.date,
-			resolve: (source) => source._.changedAt,
-		},
+		createdAt: keystoneTypes.datetime(Meetup.fields.createdAt),
+		changedAt: keystoneTypes.datetime(Meetup.fields.changedAt),
 	},
 });
 

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -104,7 +104,10 @@ var talkType = new GraphQL.GraphQLObjectType({
 			type: new GraphQL.GraphQLNonNull(meetupType),
 			description: 'The Meetup the talk is scheduled for'
 		},
-		// TODO: who (relationship to User)
+		who: {
+			type: new GraphQL.GraphQLList(userType),
+			description: 'A list of at least one User running the talk'
+		},
 		description: {
 			type: GraphQL.GraphQLString
 		},
@@ -118,8 +121,39 @@ var talkType = new GraphQL.GraphQLObjectType({
 });
 
 function getTalk (id) {
-	return Talk.model.findById(id);
+	/**
+	* TODO reduce query cost and run second query in who field `resolve` function
+	* making the who lookup optional
+	*/
+	return Talk.model.findById(id).populate('who').exec();
 }
+
+var userType = new GraphQL.GraphQLObjectType({
+	name: 'User',
+	fields: () => ({
+		name: {
+			type: new GraphQL.GraphQLNonNull(userNameType)
+		},
+		email: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+		}
+	})
+});
+
+var userNameType = new GraphQL.GraphQLObjectType({
+	name: 'UserName',
+	fields: () => ({
+		first: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+		},
+		last: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+		},
+		full: {
+			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString)
+		}
+	})
+});
 
 var queryRootType = new GraphQL.GraphQLObjectType({
 	name: 'Query',

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -51,16 +51,19 @@ var meetupType = new GraphQL.GraphQLObjectType({
 			description: 'The name of the meetup.',
 		},
 		publishedDate: {
-			type: GraphQL.GraphQLString,
+			type: keystoneTypes.date,
+			resolve: (source) => source._.publishedDate,
 		},
 		state: {
 			type: new GraphQL.GraphQLNonNull(meetupStateEnum),
 		},
 		startDate: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			type: keystoneTypes.datetime,
+			resolve: (source) => source._.startDate,
 		},
 		endDate: {
-			type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLString),
+			type: keystoneTypes.datetime,
+			resolve: (source) => source._.endDate,
 		},
 		place: {
 			type: GraphQL.GraphQLString,

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -6,6 +6,7 @@ var Meetup = keystone.list('Meetup');
 var Talk = keystone.list('Talk');
 var User = keystone.list('User');
 var RSVP = keystone.list('RSVP');
+var Organisation = keystone.list('Organisation');
 
 function getMeetup (id) {
 	if (id === 'next') {
@@ -176,6 +177,23 @@ var rsvpType = new GraphQL.GraphQLObjectType({
 	},
 });
 
+var organisationType = new GraphQL.GraphQLObjectType({
+	name: 'Organisation',
+	fields: {
+		name: { type: GraphQL.GraphQLString },
+		logo: { type: GraphQL.GraphQLString },
+		website: { type: GraphQL.GraphQLString },
+		isHiring: { type: GraphQL.GraphQLBoolean },
+		description: { type: GraphQL.GraphQLString },
+		location: { type: GraphQL.GraphQLString },
+		members: {
+			type: new GraphQL.GraphQLList(userType),
+			resolve: (source) =>
+				User.model.find().where('organisation', source.id).exec(),
+		},
+	},
+});
+
 var queryRootType = new GraphQL.GraphQLObjectType({
 	name: 'Query',
 	fields: {
@@ -198,6 +216,16 @@ var queryRootType = new GraphQL.GraphQLObjectType({
 				},
 			},
 			resolve: (_, args) => Talk.model.findById(args.id).exec(),
+		},
+		organisation: {
+			type: organisationType,
+			args: {
+				id: {
+					description: 'id of the organisation',
+					type: new GraphQL.GraphQLNonNull(GraphQL.GraphQLID),
+				},
+			},
+			resolve: (_, args) => Organisation.model.findById(args.id).exec(),
 		},
 	},
 });

--- a/graphql/scripts/printSchema.js
+++ b/graphql/scripts/printSchema.js
@@ -1,0 +1,11 @@
+// TODO require the parts of Keystone needed for this script to work
+var fs = require('fs');
+var path = require('path');
+var schema = require('../schema');
+var printSchema = require('graphql/utilities').printSchema;
+
+// Save user readable type system shorthand of schema to help DX
+fs.writeFileSync(
+  path.join(__dirname, '../schema.graphql'),
+  printSchema(schema)
+);

--- a/graphql/scripts/printSchema.js
+++ b/graphql/scripts/printSchema.js
@@ -1,4 +1,5 @@
 // TODO require the parts of Keystone needed for this script to work
+require('../../keystone');
 var fs = require('fs');
 var path = require('path');
 var schema = require('../schema');
@@ -9,3 +10,4 @@ fs.writeFileSync(
   path.join(__dirname, '../schema.graphql'),
   printSchema(schema)
 );
+process.exit();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express-graphql": "^0.4.5",
     "graphql": "^0.4.14",
     "history": "^1.12.0",
-    "keystone": "0.3.15",
+    "keystone": "https://github.com/keystonejs/keystone.git",
     "lodash": "^3.10.1",
     "moment": "^2.10.6",
     "newrelic": "^1.24.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "crypto": "0.0.3",
     "dotenv": "^1.2.0",
     "express-graphql": "^0.4.5",
-    "graphql": "^0.4.13",
+    "graphql": "^0.4.14",
     "history": "^1.12.0",
     "keystone": "0.3.15",
     "lodash": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "connect-mongo": "^0.8.2",
     "crypto": "0.0.3",
     "dotenv": "^1.2.0",
+    "express-graphql": "^0.4.5",
     "graphql": "^0.4.13",
     "history": "^1.12.0",
     "keystone": "0.3.15",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "npm": "1.3.x"
   },
   "scripts": {
-    "start": "node keystone.js"
+    "start": "node keystone.js",
+    "print-graphql-schema": "node ./graphql/scripts/printSchema.js"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,8 @@ var browserify = require('browserify-middleware');
 var clientConfig = require('../client/config');
 var keystone = require('keystone');
 var middleware = require('./middleware');
+var graphqlHTTP = require('express-graphql');
+var graphQLSchema = require('../graphql/schema');
 
 var importRoutes = keystone.importer(__dirname);
 
@@ -48,6 +50,9 @@ exports = module.exports = function (app) {
 		external: clientConfig.packages,
 		transform: ['babelify'],
 	}));
+
+	// GraphQL
+	app.use('/api/graphql', graphqlHTTP({ schema: graphQLSchema, graphiql: true }));
 
 	// Allow cross-domain requests (development only)
 	if (process.env.NODE_ENV !== 'production') {
@@ -100,9 +105,6 @@ exports = module.exports = function (app) {
 
 	// Tools
 	app.all('/notification-center', routes.views.tools['notification-center']);
-
-	// GraphQL API
-	app.post('/api/graphql', bodyParser.text({ type: 'application/graphql' }), routes.api.graphql);
 
 	// API
 	app.all('/api*', keystone.middleware.api);


### PR DESCRIPTION
Add `GraphQLObjectType`'s for the following 5 SydJS Keystone models. Include there fields and relationships. Resolve through Mongoose calls.
- [x] `Meetup`
- [x] `Talk`
- [x] `RSVP`
- [ ] `User` is done but not all the fields. There are a lot of them and include subsections. Either we could make `GraphQLObjectType`'s for the subsections e.g github or just have lots of nullable fields on the User type. Will discuss with @JedWatson.
- [x] `Organisation`

Misc
 - [ ] Create `GraphQLObjectType`'s for all the used Keystone [field types](http://keystonejs.com/docs/database/#fieldtypes) to [keystoneTypes.js](https://github.com/albertstill/sydjs-site/blob/9e001ba94416dc58aa186098b55c149da8a6e022/graphql/keystoneTypes.js). These are generic and could later be merged into Keystone itself. A few have been done but there are some left to do.

Once merged I will make another PR for the additional [GraphQL Relay Specifications](https://facebook.github.io/relay/docs/graphql-relay-specification.html#content). They will include object identifications and connections.