### PR TITLE
Add a html file for YouTube channel website association verification

### DIFF
--- a/public/google63734f6afdcc1dd5.html
+++ b/public/google63734f6afdcc1dd5.html
@@ -1,0 +1,1 @@
+google-site-verification: google63734f6afdcc1dd5.html


### PR DESCRIPTION
I'm in the process of setting up the YouTube channel for SydJS and YT requires a site verification before we can list the website on the channel. If you prefer an alternative to adding the file to the public dir (it just needs to be available from the root of the site), we could add a meta tag for it instead.