### PR TITLE
Removing redundant About link

### DIFF
--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -13,7 +13,6 @@ exports.initLocals = function(req, res, next) {
 
 	locals.navLinks = [
 		{ label: 'Home',			key: 'home',		href: '/' },
-		{ label: 'About',			key: 'about',		href: '/about' },
 		{ label: 'Code of Conduct',	key: 'about',		href: '/about#CoC' },
 		{ label: 'Meetups',			key: 'meetups',		href: '/meetups' },
 		{ label: 'Members',			key: 'members',		href: '/members' },


### PR DESCRIPTION
Removing the redundant About link in preference for the Code of Conduct
link.

MUCH more relevant :)