### PR TITLE
Updating keystone version to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "graphql": "0.4.18",
     "graphql-relay": "0.3.6",
     "jade": "1.11.0",
-    "keystone": "https://github.com/keystonejs/keystone.git#f3083c",
+    "keystone": "^4.0.0-beta.7",
     "lodash": "3.10.1",
     "moment": "2.12.0",
     "newrelic": "1.26.2",


### PR DESCRIPTION
Updating keystone version with the equivalent npm package rather than referencing a specific commit.